### PR TITLE
simplify the template and templateUrl check

### DIFF
--- a/modal.js
+++ b/modal.js
@@ -11,7 +11,7 @@ angular.module('btford.modal', []).
 factory('btfModal', function ($compile, $rootScope, $controller, $q, $http, $templateCache) {
   return function modalFactory (config) {
 
-    if ((+!!config.template) + (+!!config.templateUrl) !== 1) {
+    if ((!config.template) ^ (!!config.templateUrl)) {
       throw new Error('Expected modal to have exacly one of either `template` or `templateUrl`');
     }
 


### PR DESCRIPTION
if (!config.template) and (!!config.templateUrl) aren't both `true` or `false`, throwing error based on xor operation result.
