### PR TITLE
Loosen angular version in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,9 +11,9 @@
     "tests"
   ],
   "dependencies": {
-    "angular": ">=1.2.0"
+    "angular": "^1"
   },
   "devDependencies": {
-    "angular-mocks": ">=1.2.0"
+    "angular-mocks": "^1"
   }
 }


### PR DESCRIPTION
I want to use this in a project with angular 1.3. Bower complains about conflicting angular version, since `~1.2.13` doesn't satisfy `1.3.0-beta.14`
