### PR TITLE
fix invalid container

### DIFF
--- a/modal.js
+++ b/modal.js
@@ -17,7 +17,6 @@ factory('btfModal', function ($animate, $compile, $rootScope, $controller, $q, $
     var template      = config.template,
         controller    = config.controller || angular.noop,
         controllerAs  = config.controllerAs,
-        container     = angular.element(config.container || document.body),
         element       = null,
         container     = angular.element(document.body),
         html,

--- a/modal.js
+++ b/modal.js
@@ -19,6 +19,7 @@ factory('btfModal', function ($animate, $compile, $rootScope, $controller, $q, $
         controllerAs  = config.controllerAs,
         container     = angular.element(config.container || document.body),
         element       = null,
+        container     = angular.element(document.body),
         html,
         scope;
 
@@ -47,6 +48,9 @@ factory('btfModal', function ($animate, $compile, $rootScope, $controller, $q, $
       element = angular.element(html);
       if (element.length === 0) {
         throw new Error('The template contains no elements; you need to wrap text nodes')
+      }
+      if (config.container) {
+        container = angular.element(config.container);
       }
       $animate.enter(element, container);
       scope = $rootScope.$new();


### PR DESCRIPTION
hi, 

   I found `container` would be invalid when route changed, so I just select it every time when `config.container` is set by user. Does that make sense?

thanks.
