### PR TITLE
fix: compatibility with angular-animate 1.3

### DIFF
--- a/modal.js
+++ b/modal.js
@@ -65,7 +65,7 @@ factory('btfModal', function ($animate, $compile, $rootScope, $controller, $q, $
     function deactivate () {
       var deferred = $q.defer();
       if (element) {
-        $animate.leave(element, function () {
+        $animate.leave(element).then(function () {
           scope.$destroy();
           element = null;
           deferred.resolve();


### PR DESCRIPTION
`$angular.leave()` returns a promise now
